### PR TITLE
Add nornir routeros plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 # Service files
 config.yaml
 nornir.log
+temp.pkl
 .temp.pkl
 
 *.swp

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ nornir_cli
 
 * **Json input. Json output**
 
-    Json strings are everywhere! Ok, only in command options and arguments
+    Json strings are everywhere! Command options and arguments accept json strings. Use this feature in your scripts with the `jq`, `jc` utilities
 
 * **Custom Multi Commands with click**
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -84,6 +84,90 @@
     # of course, the same thing can be done without a configuration file
     ```
 
+Or the same, but with json string arguments:
+
+=== "one:"
+    ```text
+    # as one comand with config.yaml
+
+    $ nornir_cli nornir-netmiko init -u username -p password \
+    filter --hosts -a 'name__contains=dev_1 device_role__name__contains=leaf' \
+    netmiko_send_command '{"command_string":"display clock"}'
+    [
+        "dev_1"
+    ]
+    netmiko_send_command************************************************************
+    * dev_1 ** changed : False *****************************************************
+    vvvv netmiko_send_command ** changed : False vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv INFO
+    2021-03-21 23:15:23+03:00
+    Sunday
+    Time Zone(Moscow) : UTC+03:00
+    ^^^^ END netmiko_send_command ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    dev_1            : ok=1               changed=0               failed=0
+
+    OK      : 1
+    CHANGED : 0
+    FAILED  : 0
+    ```
+=== "two:"
+    ```text
+    # as one comand without config.yaml
+
+    $ nornir_cli nornir-netmiko init -u username -p password -c "" -f \
+    '{"inventory":{"plugin":"NetBoxInventory2", "options": {"nb_url": "your_netbox_domain", \
+    "nb_token": "your_netbox_token", "ssl_verify": false}}, \
+    "runner":{"plugin": "threaded", "options": {"num_workers": 50}} \
+    "logging":{"enabled":true, "level": "DEBUG", "to_console": true}}' \
+    filter --hosts -a 'name__contains=dev_1 \
+    device_role__name__contains=leaf' netmiko_send_command '{"command_string":"display clock"}'
+
+    netmiko_send_command************************************************************
+    * dev_1 ** changed : False *****************************************************
+    vvvv netmiko_send_command ** changed : False vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv INFO
+    2021-03-21 23:20:53+03:00
+    Sunday
+    Time Zone(Moscow) : UTC+03:00
+    ^^^^ END netmiko_send_command ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    dev_1            : ok=1               changed=0               failed=0
+
+    OK      : 1
+    CHANGED : 0
+    FAILED  : 0
+    ```
+=== "three:"
+    ```text
+    # as many commands with config.yaml
+
+    $ nornir_cli nornir-netmiko init -u username -p password
+
+    $ nornir_cli nornir-netmiko filter --hosts -a -s 'name__contains=dev_1 device_role__name__contains=leaf'
+    [
+        "dev_1"
+    ]
+
+    $ nornir_cli nornir-netmiko netmiko_send_command '{"command_string":"display clock"}'
+
+    netmiko_send_command************************************************************
+    * dev_1 ** changed : False *****************************************************
+    vvvv netmiko_send_command ** changed : False vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv INFO
+    2021-03-21 23:30:13+03:00
+    Sunday
+    Time Zone(Moscow) : UTC+03:00
+    ^^^^ END netmiko_send_command ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    dev_1            : ok=1               changed=0               failed=0
+
+    OK      : 1
+    CHANGED : 0
+    FAILED  : 0
+    ```
+=== "four:"
+    ```text
+    # of course, the same thing can be done without a configuration file
+    ```
+
 #### Task chains
 
 ```text
@@ -91,9 +175,9 @@
 
 $ nornir_cli nornir-scrapli init -u username -p password \
 -co '{"scrapli": {"platform": "huawei_vrp", "extras":{"ssh_config_file": true}}}' \
-filter --hosts -s 'name=dev_1' send_command --command "display clock" \
-send_interactive --interact_events '[["save", "Are you sure to continue?[Y/N]", \
-false], ["Y", "Save the configuration successfully.", true]]'
+filter --hosts -s 'name=dev_1' send_command '{"command":"display clock"}' \
+send_interactive '{"interact_events":[["save", "Are you sure to continue?[Y/N]", \
+false], ["Y", "Save the configuration successfully.", true]]}'
 [
     "dev_1"
 ]
@@ -276,7 +360,9 @@ FAILED  : 0
 
 #### routeros 
 
-!!! update `nornir_cli` is not compatible with `nornir-routeros` since `0.3.0` version. `nornir-routeros` has been removed from `nornir_cli 1.2.0`.
+`nornir_cli` is not compatible with `nornir-routeros` since `0.3.0` version. `nornir-routeros` has been removed from `nornir_cli 1.2.0`.
+
+But starting from `nornir_cli` version `1.3.0`, you can pass any additional arguments as a json string to Nornir plugin commands. This feature allows you to run any Nornir plugin command without an unique set of parameters.
 
 === "config.yaml:"
     ```yaml
@@ -302,7 +388,7 @@ FAILED  : 0
     ```
 === "routeros_command:"
     ```text
-    $ nornir_cli nornir-routeros init -c "/home/user/config.yaml" routeros_command --path / --command  ping --command_args '{"address": "1.1.1.1", "count": "4"}'
+    $ nornir_cli nornir-routeros init -c "/home/user/config.yaml" routeros_command '{"path":"/", "command":"ping", "address": "1.1.1.1", "count":4}'
 
     routeros_command****************************************************************
     * dev_1 ** changed : False *****************************************************
@@ -426,7 +512,7 @@ The help option can be used anywhere, for example:
 $ nornir_cli nornir-netmiko init -u username -p password filter \
 --hosts -a -s 'name__contains=dev_1 device_role__name__contains=leaf' \
 netmiko_save_config --help
-Usage: nornir_cli nornir-netmiko netmiko_save_config [OPTIONS]
+Usage: nornir_cli nornir-netmiko netmiko_save_config [OPTIONS] [ARGUMENTS]
 
   Execute Netmiko save_config method
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@
 
 * **Json input. Json output**
 
-    Json strings are everywhere! Ok, only in command options and arguments
+    Json strings are everywhere! Command options and arguments accept json strings. Use this feature in your scripts with the `jq`, `jc` utilities
 
 * **Custom Multi Commands with click**
 
@@ -73,7 +73,7 @@ docker build -t timeforplanb123/nornir_cli .
 docker run --rm -it timeforplanb123/nornir_cli sh
 
 # nornir_cli --version
-nornir_cli, version 1.2.0
+nornir_cli, version 1.3.0
 ```
 
 #### Simple Example

--- a/examples/custom_runbooks/aaa/cmd_create_fw_users.py
+++ b/examples/custom_runbooks/aaa/cmd_create_fw_users.py
@@ -29,9 +29,7 @@ SERVICE_TYPES_ERROR_MESSAGE = (
 SPECIAL_CHARACTERS = "'\"[!@#$%^&*()-+?_=,<>}{~:]/\"'"
 
 
-def validate_user_parameters(
-    task, valid_user_parameters, current_user_parameters
-):
+def validate_user_parameters(task, valid_user_parameters, current_user_parameters):
     for dict_0, dict_1 in zip(valid_user_parameters, current_user_parameters):
         if dict_0 != dict_1:
             return Result(host=task.host, result="Validation error")
@@ -119,9 +117,7 @@ def cli(ctx, usernames, role, service_types):
         template = task.run(
             task=template_file,
             name="Create template",
-            path=os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "templates"
-            ),
+            path=os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates"),
             template="create_fw_user.j2",
         )
 
@@ -165,15 +161,13 @@ def cli(ctx, usernames, role, service_types):
         f, ch = (result[host].failed, result[host].changed)
         if f:
             click.secho(
-                f"{host:<25}: Oh! Here is some exception:"
-                f" {result[host].exception}",
+                f"{host:<25}: Oh! Here is some exception:" f" {result[host].exception}",
                 fg="red",
                 bold=True,
             )
         elif ch:
             click.secho(
-                f"{host:<25}: {' '.join(usernames)}"
-                " have been created or changed",
+                f"{host:<25}: {' '.join(usernames)}" " have been created or changed",
                 fg="yellow",
                 bold=True,
             )

--- a/examples/custom_runbooks/dhcp_snooping/cmd_dhcp_snooping.py
+++ b/examples/custom_runbooks/dhcp_snooping/cmd_dhcp_snooping.py
@@ -28,7 +28,8 @@ def cli(ctx):
             command_string="disp int",
             use_textfsm=True,
             textfsm_template=os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "templates/disp_int.template"
+                os.path.dirname(os.path.abspath(__file__)),
+                "templates/disp_int.template",
             ),
         )
         # Get trusted interfaces
@@ -44,9 +45,7 @@ def cli(ctx):
         # Render j2 template
         template = task.run(
             task=template_file,
-            path=os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "templates"
-            ),
+            path=os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates"),
             template="dhcp_snooping.j2",
         )
         # Configure commands from j2 template

--- a/nornir_cli/common_commands/__init__.py
+++ b/nornir_cli/common_commands/__init__.py
@@ -1,6 +1,7 @@
 from nornir_cli.common_commands.common import (
     _doc_generator,
     _get_lists,
+    _get_dict_from_json_string,
     _json_loads,
     _pickle_to_hidden_file,
     _validate_connection_options,
@@ -27,6 +28,7 @@ from nornir_cli.common_commands.write_results import write_results
 __all__ = (
     "_doc_generator",
     "_get_lists",
+    "_get_dict_from_json_string",
     "_json_loads",
     "_pickle_to_hidden_file",
     "_validate_connection_options",

--- a/nornir_cli/common_commands/cmd_filter.py
+++ b/nornir_cli/common_commands/cmd_filter.py
@@ -7,6 +7,7 @@ from nornir.core.filter import F
 from nornir_cli.common_commands import (
     SHOW_INVENTORY_OPTIONS,
     _get_lists,
+    _get_dict_from_json_string,
     _json_loads,
     _pickle_to_hidden_file,
     common_options,
@@ -90,9 +91,7 @@ def cli(ctx, advanced_filter, f, save, **kwargs):
         if advanced_filter:
             ctx.obj["nornir"] = _get_obj_after_adv_filter(ctx.obj["nornir"], f)
         else:
-            d = dict(
-                [_json_loads(i) for i in (value.split("=") for value in _get_lists(f))]
-            )
+            d = _get_dict_from_json_string(f)
             ctx.obj["nornir"] = ctx.obj["nornir"].filter(**d)
         if save:
             _pickle_to_hidden_file("temp.pkl", obj=ctx.obj["nornir"])
@@ -100,7 +99,7 @@ def cli(ctx, advanced_filter, f, save, **kwargs):
         # run show_inventory command
         if any(kwargs.values()):
             ctx.invoke(show_inventory, **kwargs)
-    except (ValueError, IndexError):
+    except (ValueError, TypeError, IndexError):
         raise ctx.fail(
             click.BadParameter(
                 f"{ERROR_MESSAGE}",

--- a/nornir_cli/common_commands/cmd_filter.py
+++ b/nornir_cli/common_commands/cmd_filter.py
@@ -19,16 +19,22 @@ ERROR_MESSAGE = (
     "Filter optiions. There should be something like...\n\n"
     "Simple filtering:\n"
     "   nornir_cli nornir-netmiko <init> filter site=cmh role=spine\n\n"
+    "Or:\n"
+    '   nornir_cli nornir-netmiko <init> filter \'{"name":"spine_1"}\'\n\n'
     "Simple filtering with json:\n"
     "   nornir_cli nornir-netmiko <init> filter --hosts "
-    '\'primary_ip={"address": "10.1.129.71/32", "family": 4, "id": 4482, '
+    '\'primary_ip={"address": "10.1.10.10/32", "family": 4, "id": 4482, '
     '"url": "http://netbox-domain/api/ipam/ip-addresses/4482/"} name=spine_1\'\n\n'
+    "The same:\n"
+    "   nornir_cli nornir-netmiko <init> filter --hosts "
+    '\'{"primary_ip":{"address": "10.1.10.10/32", "family": 4, "id": 4482, '
+    '"url": "http://netbox-domain/api/ipam/ip-addresses/4482/"}, "name":"spine_1"}\'\n\n'
     "Advanced filtering:\n"
     "   nornir_cli nornir-netmiko <init> filter -a "
-    "'name__contains=cmh device_role__name__contains=access'\n"
+    "'name__contains=cmh device_role__name__contains=access'\n\n"
     "The same:\n"
     "   nornir_cli nornir-netmiko <init> filter -a "
-    "'name__contains=cmh & device_role__name__contains=access'\n"
+    "'name__contains=cmh & device_role__name__contains=access'\n\n"
     "Or:\n"
     "   nornir_cli nornir-netmiko <init> filter -a "
     "'name__contains=cmh | name__contains=access'\n\n"

--- a/nornir_cli/common_commands/cmd_init.py
+++ b/nornir_cli/common_commands/cmd_init.py
@@ -7,6 +7,7 @@ from nornir_cli.common_commands import (
     CONNECTION_OPTIONS,
     SHOW_INVENTORY_OPTIONS,
     _get_lists,
+    _get_dict_from_json_string,
     _json_loads,
     _pickle_to_hidden_file,
     common_options,
@@ -93,16 +94,10 @@ def cli(
     ctx.ensure_object(dict)
 
     try:
-
         TransformFunctionRegister.register("adapt_host_data", adapt_host_data)
 
         if from_dict:
-            d = dict(
-                [
-                    _json_loads(i)
-                    for i in (value.split("=") for value in _get_lists(from_dict))
-                ]
-            )
+            d = _get_dict_from_json_string(from_dict)
             cf = (
                 None
                 if not config_file or config_file == "None" or "null"
@@ -135,11 +130,11 @@ def cli(
                 f"{ERROR_MESSAGE}",
             ).format_message(),
         )
-    except (AttributeError):
+    except AttributeError:
         ctx.fail(
             f"File '{config_file}' is empty",
         )
-    except (FileNotFoundError):
+    except FileNotFoundError:
         raise ctx.fail(
             click.BadParameter(
                 f"Path '{config_file}' does not exist",

--- a/nornir_cli/common_commands/cmd_init.py
+++ b/nornir_cli/common_commands/cmd_init.py
@@ -32,10 +32,20 @@ ERROR_MESSAGE = (
     '"/home/user/inventory/hosts.yaml", "group_file": '
     '"/home/user/inventory/groups.yaml", '
     '"defaults_file": "/home/user/inventory/defaults.yaml"}}\'\n\n'
+    "The same:\n"
+    '   nornir_cli nornir-scrapli init -c "" -f '
+    '\'{"inventory":{"plugin":"SimpleInventory",options": {"host_file": '
+    '"/home/user/inventory/hosts.yaml", "group_file": '
+    '"/home/user/inventory/groups.yaml", '
+    '"defaults_file": "/home/user/inventory/defaults.yaml"}}}\'\n\n'
     "With combination of both methods:\n"
     '   nornir_cli nornir-napalm init -f \'logging={"enabled": true, "level":'
     '"DEBUG",'
-    '"to_console": false}'
+    '"to_console": false}\'\n\n'
+    "The same:\n"
+    '   nornir_cli nornir-napalm init -f \'{"logging":{"enabled": true, "level":'
+    '"DEBUG",'
+    '"to_console": false}}\''
 )
 
 

--- a/nornir_cli/common_commands/cmd_show_inventory.py
+++ b/nornir_cli/common_commands/cmd_show_inventory.py
@@ -11,7 +11,6 @@ from nornir_cli.common_commands import (
 
 
 def _get_inventory(nr_obj, count, **kwargs):
-
     d = {
         str: dict,
         bool: list,
@@ -24,7 +23,6 @@ def _get_inventory(nr_obj, count, **kwargs):
 
     for k, v in kwargs.items():
         if v:
-
             if v == "all":
                 for inventory_key in ("hosts", "groups", "defaults"):
                     for item in _get_inventory(nr_obj, count, inventory=inventory_key):

--- a/nornir_cli/common_commands/cmd_write_file.py
+++ b/nornir_cli/common_commands/cmd_write_file.py
@@ -18,7 +18,6 @@ def cli(ctx, filename, content, append, line_feed):
     """
 
     try:
-
         dirname = os.path.dirname(filename)
         Path(dirname).mkdir(parents=True, exist_ok=True)
 

--- a/nornir_cli/common_commands/common.py
+++ b/nornir_cli/common_commands/common.py
@@ -139,7 +139,7 @@ def _get_lists(s):
         begin = list(takewhile(lambda x: "=" in x, s))
         s = list(dropwhile(lambda x: "=" in x, s))
         begin.extend([i for i in takewhile(lambda x: "=" not in x, s)])
-        body.append("".join(begin))
+        body.append(" ".join(begin))
         s = list(dropwhile(lambda x: "=" not in x, s))
     return body
 
@@ -209,3 +209,16 @@ def multiple_progress_bar(task, method, pg_bar, **kwargs):
     task.run(task=method, **kwargs)
     if pg_bar:
         pg_bar.update()
+
+
+# json_string to dict function
+def _get_dict_from_json_string(json_string):
+    if "=" in json_string:
+        return dict(
+            [
+                _json_loads(i)
+                for i in (value.split("=") for value in _get_lists(json_string))
+            ]
+        )
+    else:
+        return _json_loads([json_string])[0]

--- a/nornir_cli/common_commands/static_options.py
+++ b/nornir_cli/common_commands/static_options.py
@@ -36,6 +36,10 @@ PLUGIN_OPTIONS = [
         default=True,
         show_default=True,
     ),
+    click.argument(
+        "arguments",
+        required=False,
+    ),
 ]
 
 PRINT_RESULT_WRITE_RESULT_OPTIONS = [

--- a/nornir_cli/common_commands/write_result.py
+++ b/nornir_cli/common_commands/write_result.py
@@ -45,7 +45,6 @@ def _write_individual_result(
     write_host: bool = False,
     no_errors: bool = False,
 ) -> None:
-
     # ignore results with a specifig severity_level
     if result.severity_level < severity_level:
         return
@@ -93,7 +92,6 @@ def _write_result(
     count: Optional[int] = None,
     no_errors: bool = False,
 ) -> None:
-
     attrs = attrs or ["diff", "result", "stdout"]
     if isinstance(attrs, str):
         attrs = [attrs]

--- a/nornir_cli/common_commands/write_results.py
+++ b/nornir_cli/common_commands/write_results.py
@@ -52,7 +52,6 @@ def _write_individual_result(
     no_errors: bool = False,
     append: bool = False,
 ) -> None:
-
     individual_result = []
 
     # ignore results with a specifig severity_level
@@ -120,13 +119,11 @@ def _write_results(
     no_errors: bool = False,
     append: bool = False,
 ) -> None:
-
     attrs = attrs or ["diff", "result", "stdout"]
     if isinstance(attrs, str):
         attrs = [attrs]
 
     if isinstance(result, AggregatedResult):
-
         result = dict(sorted(result.items()))
 
         if isinstance(count, int):

--- a/nornir_cli/nornir_cli.py
+++ b/nornir_cli/nornir_cli.py
@@ -304,16 +304,22 @@ def decorator(plugin, ctx):
                 str(default_value) if not isinstance(default_value, type) else None
             )
 
+            if not default_value and default_value not in ["", 0]:
+                ctx.obj["required_options"].append(k)
+
             click.option(
                 "--" + k,
                 default=default_value,
                 show_default=True,
-                required=False if default_value or default_value == "" else True,
+                required=False,
+                help="[required]" if k in ctx.obj["required_options"] else "",
                 type=PARAMETER_TYPES.setdefault(typ, click.STRING),
             )(cmd)
 
             # last original functions with arguments
-            ctx.obj["queue_parameters"][obj_or].update({k: v.default})
+            ctx.obj["queue_parameters"][obj_or].update(
+                {k: v.default if not isinstance(v.default, type) else default_value}
+            )
 
         # list of dictionaries with original function (key) and set of arguments (value)
         ctx.obj["queue_functions"].append(ctx.obj["queue_parameters"])
@@ -338,6 +344,9 @@ def decorator(plugin, ctx):
 
     ctx.obj["queue_parameters"][obj_or] = {}
 
+    # list with required options for obj_or
+    ctx.obj["required_options"] = []
+
     return wrapper
 
 
@@ -356,6 +365,8 @@ def init_nornir_cli(ctx):
     ctx.obj["queue_functions"] = []
     # last original functions with arguments
     ctx.obj["queue_parameters"] = {}
+    # list with required options for last plugin command
+    ctx.obj["required_options"] = []
 
 
 @dec("nornir_netmiko")

--- a/nornir_cli/nornir_cli.py
+++ b/nornir_cli/nornir_cli.py
@@ -195,7 +195,6 @@ def dec(param=None):
                         for filename in p[2]
                         if filename.endswith(".py") and filename.startswith("cmd_")
                     ]:
-
                         cmd_path = p[0].split(path)[1]
 
                         grps = cmd_path.split(os.sep)[1:]

--- a/nornir_cli/nornir_cli.py
+++ b/nornir_cli/nornir_cli.py
@@ -417,14 +417,12 @@ def nornir_f5():
     pass
 
 
-# nornir_cli is not compatible with nornir-routeros since 0.3.0 version
-# nornir-routeros has been removed from nornir_cli 1.2.0
-# @dec("nornir_routeros.plugins")
-# def nornir_routeros():
-#     """
-#     nornir_routeros plugin
-#     """
-#     pass
+@dec("nornir_routeros.plugins")
+def nornir_routeros():
+    """
+    nornir_routeros plugin
+    """
+    pass
 
 
 @dec("nornir_paramiko.plugins")

--- a/nornir_cli/plugin_commands/cmd_common.py
+++ b/nornir_cli/plugin_commands/cmd_common.py
@@ -15,7 +15,27 @@ from nornir_cli.common_commands import (
 from tqdm import tqdm
 
 
-ERROR_MESSAGE = "error"
+ERROR_MESSAGE = (
+    "Nornir plugin options and arguments.\n"
+    "Check the required options and the command format"
+    "(use json syntax for arguments).\n"
+    "There should be something like...\n\n"
+    "Only with required options:\n"
+    '   nornir_cli nornir-netmiko netmiko_send_command --command_string "disp clock"\n\n'
+    "Only with required options as an arguments(json-string):\n"
+    "   nornir_cli nornir-netmiko netmiko_send_command "
+    '\'{"command_string":"disp clock"}\'\n\n'
+    "With required options and arguments(json-string). The priority of options will be "
+    'higher, the command "disp ver" will be executed:\n'
+    "   nornir_cli nornir-netmiko netmiko_send_command "
+    '--command_string "disp ver" '
+    '\'{"command_string":"disp clock"}\'\n\n'
+    'With required options and arguments(json-string). The command "disp ver" '
+    'will be executed with the "read_timeout" argument:\n'
+    "   nornir_cli nornir-netmiko netmiko_send_command "
+    '--command_string "disp ver" '
+    "'{\"read_timeout\":11.0}'"
+)
 
 
 @click.pass_context

--- a/nornir_cli/plugin_commands/cmd_common.py
+++ b/nornir_cli/plugin_commands/cmd_common.py
@@ -39,9 +39,19 @@ def cli(ctx, pg_bar, print_result, print_stat, arguments, *args, **kwargs):
                 for key, value in kwargs.items()
                 if (key, value) not in params
             }
+
             # use arguments to update parameters
             if arguments:
                 parameters = {**_get_dict_from_json_string(arguments), **parameters}
+        missing_options = [
+            f"'--{option}'"
+            for option in ctx.obj["required_options"]
+            if parameters.get(option) == None
+        ]
+        if missing_options:
+            raise ctx.fail(
+                f"Missing options {', '.join(missing_options)}",
+            )
     except (ValueError, IndexError, TypeError, KeyError):
         raise ctx.fail(
             click.BadParameter(

--- a/nornir_cli/plugin_commands/cmd_common.py
+++ b/nornir_cli/plugin_commands/cmd_common.py
@@ -3,6 +3,8 @@ import click
 from nornir.core.plugins.connections import ConnectionPluginRegister
 
 from nornir_cli.common_commands import (
+    _get_lists,
+    _get_dict_from_json_string,
     _json_loads,
     _pickle_to_hidden_file,
     multiple_progress_bar,
@@ -13,24 +15,39 @@ from nornir_cli.common_commands import (
 from tqdm import tqdm
 
 
+ERROR_MESSAGE = "error"
+
+
 @click.pass_context
-def cli(ctx, pg_bar, print_result, print_stat, *args, **kwargs):
+def cli(ctx, pg_bar, print_result, print_stat, arguments, *args, **kwargs):
     ConnectionPluginRegister.auto_register()
 
-    # 'None' = None
-    kwargs.update({k: v for k, v in zip(kwargs, _json_loads(kwargs.values()))})
+    try:
+        # 'None' = None
+        kwargs.update({k: v for k, v in zip(kwargs, _json_loads(kwargs.values()))})
 
-    current_func_params = next(ctx.obj["queue_functions_generator"])
+        current_func_params = next(ctx.obj["queue_functions_generator"])
 
-    # try to pass not all arguments, but only the necessary ones
-    if kwargs == list(current_func_params.values())[0]:
-        function, parameters = list(current_func_params.items())[0]
-    else:
-        param_iterator = iter(current_func_params.values())
-        params = list(next(param_iterator).items())
-        function, parameters = list(current_func_params)[0], {
-            key: value for key, value in kwargs.items() if (key, value) not in params
-        }
+        # try to pass not all arguments, but only the necessary ones
+        if kwargs == list(current_func_params.values())[0] and not arguments:
+            function, parameters = list(current_func_params.items())[0]
+        else:
+            param_iterator = iter(current_func_params.values())
+            params = list(next(param_iterator).items())
+            function, parameters = list(current_func_params)[0], {
+                key: value
+                for key, value in kwargs.items()
+                if (key, value) not in params
+            }
+            # use arguments to update parameters
+            if arguments:
+                parameters = {**_get_dict_from_json_string(arguments), **parameters}
+    except (ValueError, IndexError, TypeError, KeyError):
+        raise ctx.fail(
+            click.BadParameter(
+                f"{ERROR_MESSAGE}",
+            ).format_message(),
+        )
 
     # get the current Nornir object from Commands chain or from temp.pkl file
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -538,6 +538,18 @@ nornir = ">=3.0.0,<4.0.0"
 openpyxl = ">=3.0.5,<4.0.0"
 
 [[package]]
+name = "nornir-routeros"
+version = "0.6.0"
+description = "RouterOS API plugins for nornir"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+Jinja2 = ">=2.11.2,<4.0"
+RouterOS-api = ">=0.17.0,<0.18.0"
+
+[[package]]
 name = "nornir-scrapli"
 version = "2023.7.30"
 description = "Scrapli's plugin for Nornir"
@@ -785,6 +797,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
+
+[[package]]
+name = "routeros-api"
+version = "0.17.0"
+description = "Python API to RouterBoard devices produced by MikroTik."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "ruamel.yaml"
@@ -1051,7 +1074,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-ena
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0.0"
-content-hash = "15f101459d42829d3757c5da8bade22ee4a171bab7e032b664813092164f3d23"
+content-hash = "61e9c6b76ea2a5f9feaca4ba7eec22119b6c1dd6258f1c75db940a077320ce75"
 
 [metadata.files]
 anyio = []
@@ -1096,6 +1119,7 @@ nornir-netmiko = []
 nornir-paramiko = []
 nornir-pyez = []
 nornir-pyxl = []
+nornir-routeros = []
 nornir-scrapli = []
 nornir-utils = []
 ntc-templates = []
@@ -1119,6 +1143,7 @@ pytest = []
 pyyaml = []
 requests = []
 requests-toolbelt = []
+routeros-api = []
 "ruamel.yaml" = []
 "ruamel.yaml.clib" = []
 scp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ nornir-paramiko = "0.2.0"
 nornir-http = "0.1.3"
 nornir-pyxl = "1.0.1"
 nornir-netconf = "2.0.0"
+nornir-routeros = "0.6.0"
 tqdm = "^4.64.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
`nornir_cli` is not compatible with `nornir-routeros` since `0.3.0` version. `nornir-routeros` has been removed from `nornir_cli 1.2.0`.

But starting from new `nornir_cli` version `1.3.0`, you can pass any additional arguments as a `json string` to Nornir plugin commands. This feature allows you to run any Nornir plugin command without an unique set of parameters. So, now the `nornir-routeros` plugin can be run like this:

```text
$ nornir_cli nornir-routeros init -c "/home/user/config.yaml" routeros_command '{"path":"/", "command":"ping", "address": "1.1.1.1", "count":4}'
```